### PR TITLE
fix: ts compile, node v20, test path

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "test": "node --es-module-specifier-resolution=node --experimental-fetch ./index.js",
+    "test": "node --es-module-specifier-resolution=node --experimental-fetch ./test/index.js",
     "test-n-build": "npm run build && npm run test",
     "publish": "npm run build && npm publish --access public",
     "start": "node --es-module-specifier-resolution=node --experimental-fetch ./index.js"

--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "test": "node --es-module-specifier-resolution=node --experimental-fetch ./test/index.js",
+    "test": "node --es-module-specifier-resolution=node --experimental-fetch ./index.js",
     "test-n-build": "npm run build && npm run test",
     "publish": "npm run build && npm publish --access public",
-    "start": "node --es-module-specifier-resolution=node  --experimental-fetch ./index.js"
+    "start": "node --es-module-specifier-resolution=node --experimental-fetch ./index.js"
   },
   "author": "minerj101",
   "license": "MIT",
   "dependencies": {
-    "bedrock-protocol": "^3.18.0",
-    "dotenv": "^16.0.1",
-    "prismarine-auth": "^1.5.4",
-    "query-string": "^7.1.1",
+    "bedrock-protocol": "^3.39.0",
+    "dotenv": "^16.4.5",
+    "prismarine-auth": "^1.7.0",
+    "query-string": "^7.1.3",
     "unirest": "^0.6.0",
     "websocket": "^1.0.34"
   },
@@ -34,7 +34,8 @@
   "devDependencies": {
     "@types/node": "^18.0.0",
     "@types/websocket": "^1.0.5",
-    "ts-node": "^10.8.1",
-    "friend-connect": "^0.7.6"
+    "friend-connect": "^0.7.6",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -138,9 +138,9 @@ interface MinecraftLobbyCustomProperties {
 	protocol: number;
 	version: string;
 }
-import { XboxClient, LinkCodeTokenProvider } from "./xbox";
-import { RTAMultiplayerSession } from "./xbox/modules/rta";
-import { PeopleList } from "./xbox/modules/peopleHub";
+import { XboxClient, LinkCodeTokenProvider } from "./xbox/index.js";
+import { RTAMultiplayerSession } from "./xbox/modules/rta.js";
+import { PeopleList } from "./xbox/modules/peopleHub.js";
 
 //TODO add events to the social class the emits friendAdded on response so there is no duplicateEvents same for other events. also clean up the code for the xbox live client so it returns the values instead of a response
 class Session extends EventEmitter {
@@ -628,7 +628,7 @@ class Session extends EventEmitter {
 				port: port,
 			});
 			if (!this.additionalOptions.constants.gamemode)
-				this.minecraftLobbyCustomOptions.worldType = info.gamemode;
+				this.minecraftLobbyCustomOptions.worldType = info.gamemodeId.toString();
 			if (!this.additionalOptions.constants.worldName)
 				//@ts-ignore
 				this.minecraftLobbyCustomOptions.worldName = info.levelName;

--- a/src/xbox/index.ts
+++ b/src/xbox/index.ts
@@ -1,5 +1,5 @@
 import { createHash } from "prismarine-auth/src/common/Util.js";
-import Achievements from "./modules/achievements";
+import Achievements from "./modules/achievements.js";
 import { LiveCache, MsaResponse, UserIdentifier, XboxLiveToken } from "./types";
 import authPkg from "prismarine-auth";
 const { Authflow } = authPkg;
@@ -7,9 +7,9 @@ import fs from "fs";
 import EventEmitter from "events";
 import uniRest from "unirest";
 
-import SessionDirectory from "./modules/sessionDirectory";
-import Social from "./modules/social";
-import PeopleHub from "./modules/peopleHub";
+import SessionDirectory from "./modules/sessionDirectory.js";
+import Social from "./modules/social.js";
+import PeopleHub from "./modules/peopleHub.js";
 
 interface XboxLiveTokenProvider {
 	userXuid: string;

--- a/src/xbox/modules/achievements.ts
+++ b/src/xbox/modules/achievements.ts
@@ -1,7 +1,7 @@
 import { XboxClient } from "..";
 import { GUID, UserIdentifier } from "../types";
 import { Achievement } from "../xboxRestTypes";
-import { parseIdentifier } from "../utils";
+import { parseIdentifier } from "../utils/index.js";
 interface TitleHistoryQueryStringParameters {
 	/**
 	 * Return items beginning after the given number of items. For example, skipItems="3" will retrieve items beginning with the fourth item retrieved.

--- a/src/xbox/modules/peopleHub.ts
+++ b/src/xbox/modules/peopleHub.ts
@@ -66,7 +66,7 @@ export interface PeopleList {
 
 import { XboxClient } from "../";
 import { UserIdentifier } from "../types";
-import { parseIdentifier } from "../utils";
+import { parseIdentifier } from "../utils/index.js";
 export default class PeopleHub {
 	private readonly xbox: XboxClient;
 	static readonly uri: string = "https://peoplehub.xboxlive.com";

--- a/src/xbox/modules/social.ts
+++ b/src/xbox/modules/social.ts
@@ -1,6 +1,6 @@
 import { XboxClient } from "../index";
 import { UserIdentifier } from "../types";
-import { parseIdentifier } from "../utils/index";
+import { parseIdentifier } from "../utils/index.js";
 import { Person, PersonSummary, PeopleList } from "../xboxRestTypes";
 
 export default class Social {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,104 +1,16 @@
 {
-	"compilerOptions": {
-		/* Visit https://aka.ms/tsconfig to read more about this file */
-
-		/* Projects */
-		// "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-		// "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
-		// "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-		// "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-		// "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
-		/* Language and Environment */
-		"target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-		// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
-		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
-		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-		// "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-		// "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-		// "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-		// "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-		// "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-		// "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
-		/* Modules */
-		"module": "ESNext" /* Specify what module code is generated. */,
-		// "rootDir": "./",                                  /* Specify the root folder within your source files. */
-		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
-		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
-		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
-		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-		// "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-		// "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-		// "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-		// "resolveJsonModule": true,                        /* Enable importing .json files. */
-		// "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
-		/* JavaScript Support */
-		// "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-		// "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-		// "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
-		/* Emit */
-		"declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
-		// "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-		// "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-		// "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-		"outDir": "dist" /* Specify an output folder for all emitted files. */,
-		// "removeComments": true,                           /* Disable emitting comments. */
-		// "noEmit": true,                                   /* Disable emitting files from a compilation. */
-		// "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-		// "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
-		// "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-		// "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-		// "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-		// "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-		// "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-		// "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-		// "newLine": "crlf",                                /* Set the newline character for emitting files. */
-		// "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-		// "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-		// "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-		// "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-		// "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-		// "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
-		/* Interop Constraints */
-		// "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-		"allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
-		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-		// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
-
-		/* Type Checking */
-		"strict": false /* Enable all strict type-checking options. */,
-		// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-		// "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-		// "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-		// "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-		// "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-		// "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-		// "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-		// "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-		// "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-		// "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-		// "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-		// "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-		// "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-		// "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-		// "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-		// "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-		// "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-		// "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
-		/* Completeness */
-		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-		"skipLibCheck": true /* Skip type checking all .d.ts files. */
-	},
-	"include": ["./src/*.ts", "src/xbox/xboxRestTypes.ts"]
+    "compilerOptions": {
+        "target": "es2020",
+        "module": "ESNext",
+        "moduleResolution": "node",
+        "outDir": "dist",
+        "declaration": true,
+        "sourceMap": true,
+        "allowSyntheticDefaultImports": true,
+        "esModuleInterop": true,
+        "forceConsistentCasingInFileNames": true,
+        "skipLibCheck": true,
+        "strict": false
+    },
+    "include": ["src/**/*.ts"]
 }

--- a/tsconfigexample.txt
+++ b/tsconfigexample.txt
@@ -1,0 +1,104 @@
+{
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig to read more about this file */
+
+		/* Projects */
+		// "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+		// "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+		// "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+		// "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+		// "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+		// "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+		/* Language and Environment */
+		"target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+		// "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+		// "jsx": "preserve",                                /* Specify what JSX code is generated. */
+		// "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
+		// "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+		// "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+		// "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+		// "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+		// "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+		// "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+		// "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+		// "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+		/* Modules */
+		"module": "ESNext" /* Specify what module code is generated. */,
+		// "rootDir": "./",                                  /* Specify the root folder within your source files. */
+		"moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+		// "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+		// "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+		// "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+		// "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+		// "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+		// "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+		// "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+		// "resolveJsonModule": true,                        /* Enable importing .json files. */
+		// "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+		/* JavaScript Support */
+		// "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+		// "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+		// "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+		/* Emit */
+		"declaration": true /* Generate .d.ts files from TypeScript and JavaScript files in your project. */,
+		// "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+		// "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+		// "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+		// "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+		"outDir": "dist" /* Specify an output folder for all emitted files. */,
+		// "removeComments": true,                           /* Disable emitting comments. */
+		// "noEmit": true,                                   /* Disable emitting files from a compilation. */
+		// "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+		// "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
+		// "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+		// "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+		// "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+		// "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+		// "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+		// "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+		// "newLine": "crlf",                                /* Set the newline character for emitting files. */
+		// "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+		// "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+		// "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+		// "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+		// "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+		// "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
+
+		/* Interop Constraints */
+		// "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+		"allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
+		"esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+		// "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+		"forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+
+		/* Type Checking */
+		"strict": false /* Enable all strict type-checking options. */,
+		// "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+		// "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+		// "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+		// "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+		// "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+		// "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+		// "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+		// "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+		// "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+		// "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+		// "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+		// "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+		// "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+		// "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+		// "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+		// "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+		// "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+		// "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+		/* Completeness */
+		// "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+		"skipLibCheck": true /* Skip type checking all .d.ts files. */
+	},
+	"include": ["./src/*.ts", "src/xbox/xboxRestTypes.ts"]
+}


### PR DESCRIPTION
This pull request includes several updates to dependencies, module imports, and TypeScript configuration. The most important changes include updating dependencies in `package.json`, adding `.js` extensions to module imports, and adding a TypeScript configuration example file.

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17-R20): Updated versions for `bedrock-protocol`, `dotenv`, `prismarine-auth`, and `query-string` dependencies.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L37-R39): Added `typescript` as a dev dependency and updated `ts-node` version.

### Module Imports:
* [`src/index.ts`](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80L141-R143): Added `.js` extensions to imports from `./xbox`, `./xbox/modules/rta`, and `./xbox/modules/peopleHub`.
* [`src/xbox/index.ts`](diffhunk://#diff-315619ad26d209950f7ea22a6c4586a0211f135329e1bf570eff40c67eb2722dL2-R12): Added `.js` extensions to imports from `./modules/achievements`, `./modules/sessionDirectory`, `./modules/social`, and `./modules/peopleHub`.
* `src/xbox/modules/achievements.ts`, `src/xbox/modules/peopleHub.ts`, `src/xbox/modules/social.ts`: Added `.js` extensions to imports from `../utils/index`. [[1]](diffhunk://#diff-925f5f123fcc839a50cc51f68cbe5f6ceeacbd5c9f9cb16da5eb10a7ded34946L4-R4) [[2]](diffhunk://#diff-a016d2ae3166ef5cfbe112bf5cf74aed37b604e41ae077286da99ee02d7e57fcL69-R69) [[3]](diffhunk://#diff-bce8ff1cc470223b19d110ad6fc763ecd860e5d8a9ee75ba045484fa3bb55977L3-R3)

### TypeScript Configuration:
* [`tsconfigexample.txt`](diffhunk://#diff-cce2aea989d34abdbd6d88728b58a2500648b32ad74e1ff74f8f2897b5997771R1-R104): Added a new TypeScript configuration example file with various compiler options and project settings.